### PR TITLE
Feat/adapt to LLMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 */.ipynb_checkpoints
 
 .idea
-
+.env
+venv
 examples/iris*
 examples/trainer_*

--- a/be_great/great.py
+++ b/be_great/great.py
@@ -97,17 +97,19 @@ class GReaT:
                     "This function requires the 'peft' package. Please install it with - pip install peft==0.9.0"
                 )
 
-            if not target_modules:
-                target_modules = []                
-                for name, module in self.model.named_modules():
-                    if isinstance(module, (torch.nn.Linear, torch.nn.Embedding, torch.nn.Conv2d)):
-                        target_modules.append('.'.join(name.split('.')[4:]).split('.')[0])
+            # if not target_modules:
+            #     target_modules = set()             
+            #     for name, module in self.model.named_modules():
+            #         if isinstance(module, (torch.nn.Linear, torch.nn.Embedding, torch.nn.Conv2d)):
+            #             module_name = '.'.join(name.split('.')[4:]).split('.')[0]
+            #             print(module_name)
+            #             target_modules.add(module_name)
                 
             # Define LoRA Config
             lora_config = LoraConfig(
                 r=16,  # only training 0.16% of the parameters of the model
                 lora_alpha=32,
-                target_modules=target_modules,
+                target_modules="all-linear" if not target_modules else target_modules,
                 lora_dropout=0.05,
                 bias="none",
                 task_type=TaskType.CAUSAL_LM,  # this is specific for gpt2 model, to be adapted
@@ -236,7 +238,7 @@ class GReaT:
                         max_length=max_length,
                         do_sample=True,
                         temperature=temperature,
-                        pad_token_id=50256,
+                        pad_token_id=self.tokenizer.pad_token,
                     )
 
                     # Convert tokens back to tabular data

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ tqdm >= 4.64.1
 transformers >= 4.22.1
 accelerate >= 0.20.1
 fsspec >= 2024.5.0
+peft==0.9.0
+bitsandbytes


### PR DESCRIPTION
Adapt LoRa target modules to all linear layers. Change hardcoded pad token during sampling to eos_token from tokenizer. Tested on distilgpt2 and MetaLlama3.1-8B on a new csv dataset.